### PR TITLE
Be more resilient to ColorThief exceptions

### DIFF
--- a/src/services/Asset.php
+++ b/src/services/Asset.php
@@ -43,7 +43,13 @@ class Asset extends Component
 
         // Only Extract color when forced.
         if ($forceSave && isset($asset->imageColor)) {
-            $color = $this->extractColor($asset);
+            try {
+                $color = $this->extractColor($asset);
+            } catch (\Throwable $e) {
+                Craft::error("Couldn't extract the color of asset $asset->id");
+                Craft::error($e);
+                $color = null;
+            }
 
             if (!empty($color)) {
                 $asset->setFieldValue('imageColor', $color);


### PR DESCRIPTION
I had a problem with the queue job that extracts color from all images. One of my images was not supported by the color-thief package, which resulted in an exception being thrown (Unable to compute the color palette of a blank or transparent image) and the queue job stopping without processing other images.

This fix catches and logs exceptions and returns a fallback value.